### PR TITLE
Define a feature configuration which apply to a controller action

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,7 @@
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+AnnotationRegistry::registerLoader('class_exists');

--- a/Annotation/Feature.php
+++ b/Annotation/Feature.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Novaway\Bundle\FeatureFlagBundle\Annotation;
+
+/**
+ * @Annotation
+ */
+class Feature
+{
+    /** @var string */
+    private $feature;
+
+    /** @var bool */
+    private $enabled;
+
+    /**
+     * Constructor
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        if (!isset($values['value'])) {
+            throw new \RuntimeException('Feature annotation value is required.');
+        }
+
+        $this->feature = (string) $values['value'];
+        $this->enabled = !isset($values['enabled']) || (bool) $values['enabled'];
+    }
+
+    /**
+     * Get feature name
+     *
+     * @return string
+     */
+    public function getFeature()
+    {
+        return $this->feature;
+    }
+
+    /**
+     * Get if feature should be enabled or not
+     *
+     * @return bool
+     */
+    public function getEnabled()
+    {
+        return $this->enabled;
+    }
+}

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Novaway\Bundle\FeatureFlagBundle\EventListener;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Util\ClassUtils;
+use Novaway\Bundle\FeatureFlagBundle\Annotation\Feature;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ControllerListener implements EventSubscriberInterface
+{
+    /** @var Reader */
+    private $annotationReader;
+
+    /**
+     * Constructor
+     *
+     * @param Reader $reader
+     */
+    public function __construct(Reader $reader)
+    {
+        $this->annotationReader = $reader;
+    }
+
+    /**
+     * Update the request object to apply annotation configuration
+     *
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController();
+        if (!is_array($controller) && method_exists($controller, '__invoke')) {
+            $controller = [$controller, '__invoke'];
+        }
+
+        if (!is_array($controller)) {
+            return;
+        }
+
+        $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
+        $object    = new \ReflectionClass($className);
+        $method    = $object->getMethod($controller[1]);
+
+        $features = [];
+        foreach ($this->annotationReader->getMethodAnnotations($method) as $annotation) {
+            if ($annotation instanceof Feature) {
+                $key = $annotation->getFeature();
+                if (isset($features[$key])) {
+                    throw new \UnexpectedValueException(sprintf('Feature "%s" is defined more than once for %s::%s', $key, $className, $controller[1]));
+                }
+
+                $features[$key] = [
+                    'feature' => $annotation->getFeature(),
+                    'enabled' => $annotation->getEnabled(),
+                ];
+            }
+        }
+
+        $request = $event->getRequest();
+        $request->attributes->set('_features', array_merge(
+            $request->attributes->get('_features', []),
+            $features
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+        ];
+    }
+}

--- a/EventListener/FeatureListener.php
+++ b/EventListener/FeatureListener.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Novaway\Bundle\FeatureFlagBundle\EventListener;
+
+use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class FeatureListener implements EventSubscriberInterface
+{
+    /** @var StorageInterface */
+    private $storage;
+
+    /**
+     * Constructor
+     *
+     * @param StorageInterface $storage
+     */
+    public function __construct(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * Check if a feature requirement is defined
+     *
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+        if (!$features = $request->attributes->get('_features')) {
+            return;
+        }
+
+        foreach ($features as $featureConfiguration) {
+            if ($featureConfiguration['enabled'] !== $this->storage->check($featureConfiguration['feature'])) {
+                throw new NotFoundHttpException();
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+        ];
+    }
+}

--- a/Model/Feature.php
+++ b/Model/Feature.php
@@ -18,11 +18,13 @@ class Feature implements FeatureInterface
      *
      * @param string $key
      * @param bool   $enabled
+     * @param string $description
      */
-    public function __construct($key, $enabled)
+    public function __construct($key, $enabled, $description = null)
     {
         $this->key = $key;
         $this->enabled = (bool) $enabled;
+        $this->description = $description;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -98,6 +98,61 @@ You can also check a flag in your templates:
 {% endif %}
 ```
 
+#### In the routing configuration
+
+The package allow you to restrict a controller access by adding some configuration in your routing definition.
+
+```yaml
+# app/config/routing.yml
+my_first_route:
+    path: /my/first/route
+    defaults:
+        _controller: AppBundle:Default:index
+        _features:
+            - { feature: my_feature_key, enabled: false } # The action is accessible if "my_feature_key" is disabled
+            
+my_second_route:
+    path: /my/second-route
+    defaults:
+        _controller: AppBundle:Default:second
+        _features:
+            - { feature: foo } # The action is accessible if "foo" is enabled ...
+            - { feature: bar, enabled: true } # ... and "bar" feature is also enabled
+```
+
+#### As a controller annotation
+
+You can also restrict a controller access with annotations :
+
+```php
+class MyController extends Controller
+{
+    /**
+     * @Feature("foo")
+     */
+    public function annotationFooEnabledAction()
+    {
+        return new Response('MyController::annotationFooEnabledAction');
+    }
+    
+    /**
+     * @Feature("foo", enabled=true)
+     */
+    public function annotationFooEnabledBisAction()
+    {
+        return new Response('MyController::annotationFooEnabledAction');
+    }
+
+    /**
+     * @Feature("foo", enabled=false)
+     */
+    public function annotationFooDisabledAction()
+    {
+        return new Response('MyController::annotationFooDisabledAction');
+    }
+}
+```
+
 ### Implement your own storage provider
 
 1. First your need to create your storage provider class which implement the `Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface` interface

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,11 @@
 services:
+    novaway_feature_flag.listener.feature:
+        class: Novaway\Bundle\FeatureFlagBundle\EventListener\FeatureListener
+        arguments:
+            - "@novaway_feature_flag.manager.feature"
+        tags:
+            - { name: kernel.event_subscriber }
+
     novaway_feature_flag.storage.default:
         class: Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage
         arguments:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,11 @@
 services:
+    novaway_feature_flag.listener.controller:
+        class: Novaway\Bundle\FeatureFlagBundle\EventListener\ControllerListener
+        arguments:
+            - "@annotation_reader"
+        tags:
+            - { name: kernel.event_subscriber }
+
     novaway_feature_flag.listener.feature:
         class: Novaway\Bundle\FeatureFlagBundle\EventListener\FeatureListener
         arguments:

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Novaway\Bundle\FeatureFlagBundle\Storage;
+
+abstract class AbstractStorage implements StorageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled($feature)
+    {
+        return true === $this->check($feature);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDisabled($feature)
+    {
+        return false === $this->check($feature);
+    }
+}

--- a/Storage/ArrayStorage.php
+++ b/Storage/ArrayStorage.php
@@ -5,7 +5,7 @@ namespace Novaway\Bundle\FeatureFlagBundle\Storage;
 use Novaway\Bundle\FeatureFlagBundle\Model\Feature;
 use Novaway\Bundle\FeatureFlagBundle\Model\FeatureInterface;
 
-class ArrayStorage implements StorageInterface
+class ArrayStorage extends AbstractStorage
 {
     /** @var FeatureInterface[] */
     private $features;
@@ -39,20 +39,12 @@ class ArrayStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function isEnabled($feature)
+    public function check($feature)
     {
         if (!isset($this->features[$feature])) {
             return false;
         }
 
         return $this->features[$feature]->isEnabled();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isDisabled($feature)
-    {
-        return false === $this->isEnabled($feature);
     }
 }

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -14,6 +14,14 @@ interface StorageInterface
     public function all();
 
     /**
+     * Check if feature is enabled or not
+     *
+     * @param string $feature
+     * @return bool
+     */
+    public function check($feature);
+
+    /**
      * Check if feature is enabled
      *
      * @param string $feature

--- a/Tests/Fixtures/TestBundle/Controller/DefaultController.php
+++ b/Tests/Fixtures/TestBundle/Controller/DefaultController.php
@@ -3,6 +3,7 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\TestBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends Controller
 {
@@ -16,5 +17,15 @@ class DefaultController extends Controller
             'feature_foo_disabled' => $featureManager->isDisabled('foo'),
             'feature_bar_disabled' => $featureManager->isDisabled('bar'),
         ]);
+    }
+
+    public function requestFooEnabledAction()
+    {
+        return new Response('DefaultController::requestFooEnabledAction');
+    }
+
+    public function requestFooDisabledAction()
+    {
+        return new Response('DefaultController::requestFooDisabledAction');
     }
 }

--- a/Tests/Fixtures/TestBundle/Controller/DefaultController.php
+++ b/Tests/Fixtures/TestBundle/Controller/DefaultController.php
@@ -2,6 +2,7 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\TestBundle\Controller;
 
+use Novaway\Bundle\FeatureFlagBundle\Annotation\Feature;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,5 +28,21 @@ class DefaultController extends Controller
     public function requestFooDisabledAction()
     {
         return new Response('DefaultController::requestFooDisabledAction');
+    }
+
+    /**
+     * @Feature("foo")
+     */
+    public function annotationFooEnabledAction()
+    {
+        return new Response('DefaultController::annotationFooEnabledAction');
+    }
+
+    /**
+     * @Feature("foo", enabled=false)
+     */
+    public function annotationFooDisabledAction()
+    {
+        return new Response('DefaultController::annotationFooDisabledAction');
     }
 }

--- a/Tests/Fixtures/config/routing.yml
+++ b/Tests/Fixtures/config/routing.yml
@@ -1,5 +1,21 @@
 features:
     path:         /features
     defaults:     { _controller: TestBundle:Default:features }
-    requirements: { _method': GET }
 
+request_configuration_enabled:
+    path: /request/enabled
+    defaults:
+        _controller: TestBundle:Default:requestFooEnabled
+        _features:
+            -
+                feature: foo
+                enabled: true
+
+request_configuration_disabled:
+    path: /request/disabled
+    defaults:
+        _controller: TestBundle:Default:requestFooDisabled
+        _features:
+            -
+                feature: foo
+                enabled: false

--- a/Tests/Fixtures/config/routing.yml
+++ b/Tests/Fixtures/config/routing.yml
@@ -19,3 +19,11 @@ request_configuration_disabled:
             -
                 feature: foo
                 enabled: false
+
+annotation_configuration_enabled:
+    path:     /annotation/enabled
+    defaults: { _controller: TestBundle:Default:annotationFooEnabled }
+
+annotation_configuration_disabled:
+    path:     /annotation/disabled
+    defaults: { _controller: TestBundle:Default:annotationFooDisabled }

--- a/Tests/Functionals/Fixtures/TestBundle/Controller/DefaultController.php
+++ b/Tests/Functionals/Fixtures/TestBundle/Controller/DefaultController.php
@@ -63,6 +63,32 @@ class DefaultController extends WebTestCase
                     ->isEqualTo(404)
         ;
     }
+
+    public function testAnnotationFooEnabledAction()
+    {
+        $this
+            ->if($client = $this->createClient())
+            ->then
+                ->given($crawler = $client->request('GET', '/annotation/enabled'))
                 ->boolean($client->getResponse()->isSuccessful())
                     ->isTrue()
+                ->integer($crawler->filter('html:contains("DefaultController::annotationFooEnabledAction")')->count())
+                    ->isGreaterThan(0)
+                ->integer($client->getResponse()->getStatusCode())
+                    ->isEqualTo(200)
+        ;
+    }
+
+    public function testAnnotationFooDisabledAction()
+    {
+        $this
+            ->if($client = $this->createClient())
+            ->then
+                ->given($crawler = $client->request('GET', '/annotation/disabled'))
+                ->boolean($client->getResponse()->isSuccessful())
+                    ->isFalse()
+                ->integer($client->getResponse()->getStatusCode())
+                    ->isEqualTo(404)
+        ;
+    }
 }

--- a/Tests/Functionals/Fixtures/TestBundle/Controller/DefaultController.php
+++ b/Tests/Functionals/Fixtures/TestBundle/Controller/DefaultController.php
@@ -26,7 +26,7 @@ class DefaultController extends WebTestCase
         $this
             ->if($client = $this->createClient())
             ->then
-               ->given($crawler = $client->request('GET', '/features'))
+                ->given($crawler = $client->request('GET', '/features'))
                 ->boolean($client->getResponse()->isSuccessful())
                     ->isTrue()
                 ->integer($crawler->filter('html:contains("Foo feature is disabled from controller")')->count())
@@ -35,4 +35,34 @@ class DefaultController extends WebTestCase
                     ->isGreaterThan(0)
         ;
     }
+
+    public function testRequestFooEnabled()
+    {
+        $this
+            ->if($client = $this->createClient())
+            ->then
+                ->given($crawler = $client->request('GET', '/request/enabled'))
+                ->boolean($client->getResponse()->isSuccessful())
+                    ->isTrue()
+                ->integer($crawler->filter('html:contains("DefaultController::requestFooEnabledAction")')->count())
+                    ->isGreaterThan(0)
+                ->integer($client->getResponse()->getStatusCode())
+                    ->isEqualTo(200)
+        ;
+    }
+
+    public function testRequestFooDisabled()
+    {
+        $this
+            ->if($client = $this->createClient())
+            ->then
+                ->given($crawler = $client->request('GET', '/request/disabled'))
+                ->boolean($client->getResponse()->isSuccessful())
+                    ->isFalse()
+                ->integer($client->getResponse()->getStatusCode())
+                    ->isEqualTo(404)
+        ;
+    }
+                ->boolean($client->getResponse()->isSuccessful())
+                    ->isTrue()
 }

--- a/Tests/Units/Storage/ArrayStorage.php
+++ b/Tests/Units/Storage/ArrayStorage.php
@@ -27,6 +27,24 @@ class ArrayStorage extends atoum
         ;
     }
 
+    public function testCheck()
+    {
+        $this
+            ->if($this->newTestedInstance())
+            ->then
+                ->boolean($this->testedInstance->check('foo'))->isFalse()
+
+            ->if($this->newTestedInstance([
+                'foo' => ['enabled' => false],
+                'bar' => ['enabled' => true, 'description' => 'Feature bar description'],
+            ]))
+            ->then
+                ->boolean($this->testedInstance->check('foo'))->isFalse()
+                ->boolean($this->testedInstance->check('bar'))->isTrue()
+                ->boolean($this->testedInstance->check('unknow'))->isFalse()
+        ;
+    }
+
     public function testIsEnabled()
     {
         $this

--- a/Tests/Units/Storage/ArrayStorage.php
+++ b/Tests/Units/Storage/ArrayStorage.php
@@ -3,9 +3,30 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Units\Storage;
 
 use atoum;
+use Novaway\Bundle\FeatureFlagBundle\Model\Feature;
 
 class ArrayStorage extends atoum
 {
+    public function testAll()
+    {
+        $this
+            ->if($this->newTestedInstance())
+            ->then
+                ->array($this->testedInstance->all())
+                    ->isEmpty()
+
+            ->if($this->newTestedInstance([
+                'foo' => ['enabled' => false],
+                'bar' => ['enabled' => true, 'description' => 'Feature bar description'],
+            ]))
+            ->then
+                ->given($features = $this->testedInstance->all())
+                ->array($features)
+                    ->object['foo']->isEqualTo(new Feature('foo', false))
+                    ->object['bar']->isEqualTo(new Feature('bar', true, 'Feature bar description'))
+        ;
+    }
+
     public function testIsEnabled()
     {
         $this

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4",
         "symfony/symfony": "~2.3|~3.0",
         "twig/twig": "^1.12"
     },


### PR DESCRIPTION
This PR allow developer to define controller access by checking if a feature flag is enabled or not.

### With annotation

```php
class MyController extends Controller
{
    /**
     * @Feature("foo")
     * @Feature("foo", enabled=true)
     */
    public function annotationFooEnabledAction()
    {
        return new Response('MyController::annotationFooEnabledAction');
    }

    /**
     * @Feature("foo", enabled=false)
     */
    public function annotationFooDisabledAction()
    {
        return new Response('MyController::annotationFooDisabledAction');
    }
}
```

### In the routing configuration

```yaml
# app/config/routing.yml
my_first_route:
    path: /my/first/route
    defaults:
        _controller: AppBundle:Default:index
        _features:
            - { feature: my_feature_key, enabled: false } # The action is accessible if "my_feature_key" is disabled
            
my_second_route:
    path: /my/second-route
    defaults:
        _controller: AppBundle:Default:second
        _features:
            - { feature: foo } # The action is accessible if "foo" is enabled ...
            - { feature: bar, enabled: true } # ... and "bar" feature is also enabled
```