### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=3.3.*
         - php: 5.6
-          env: SYMFONY_VERSION=3.4.*@dev
+          env: SYMFONY_VERSION=3.4.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.0.*
     allow_failures:
         - php: nightly
-        - php: 5.6
-          env: SYMFONY_VERSION=3.4.*@dev
 
 before_install:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ matrix:
         - php: 5.6
           env: COMPOSER_FLAGS="--prefer-lowest"
         - php: 5.6
-          env: SYMFONY_VERSION=2.7.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.8.*
-        - php: 5.6
           env: SYMFONY_VERSION=3.2.*
         - php: 5.6
           env: SYMFONY_VERSION=3.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 before_install:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - composer self-update
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/framework-bundle:${SYMFONY_VERSION}" --no-update; fi;
 
 install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 

--- a/DataCollector/FeatureCollector.php
+++ b/DataCollector/FeatureCollector.php
@@ -49,4 +49,12 @@ class FeatureCollector extends DataCollector
     {
         return 'novaway_feature_flag.feature_collector';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
 }

--- a/DependencyInjection/NovawayFeatureFlagExtension.php
+++ b/DependencyInjection/NovawayFeatureFlagExtension.php
@@ -23,7 +23,9 @@ class NovawayFeatureFlagExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('novaway_feature_flag.features', $config['features']);
+
         $container->setAlias('novaway_feature_flag.manager.feature', $config['storage']);
+        $container->getAlias('novaway_feature_flag.manager.feature')->setPublic(true);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/DependencyInjection/NovawayFeatureFlagExtension.php
+++ b/DependencyInjection/NovawayFeatureFlagExtension.php
@@ -30,6 +30,10 @@ class NovawayFeatureFlagExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
+        if (class_exists('Twig_Extension')) {
+            $loader->load('twig.yml');
+        }
+
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.yml');
         }

--- a/README.md
+++ b/README.md
@@ -21,15 +21,11 @@ Symfony 2.3+.
 
 Install extension using [composer](https://getcomposer.org):
 
-```json
-{
-    "require": {
-        "novaway/feature-flag-bundle": "dev-master"
-    }
-}
+```bash
+composer require novaway/feature-flag-bundle
 ```
 
-Enable the bundle in your application `AppKernel`:
+If you don't use Flex, enable the bundle in your application `AppKernel`:
 
 ```php
 <?php

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,11 +17,3 @@ services:
         class: Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage
         arguments:
             - "%novaway_feature_flag.features%"
-
-    novaway_feature_flag.twig.feature_extension:
-        class: Novaway\Bundle\FeatureFlagBundle\Twig\Extension\FeatureFlagExtension
-        public: false
-        arguments:
-            - "@novaway_feature_flag.manager.feature"
-        tags:
-            - { name: twig.extension }

--- a/Resources/config/twig.yml
+++ b/Resources/config/twig.yml
@@ -1,0 +1,8 @@
+services:
+    novaway_feature_flag.twig.feature_extension:
+        class: Novaway\Bundle\FeatureFlagBundle\Twig\Extension\FeatureFlagExtension
+        public: false
+        arguments:
+            - "@novaway_feature_flag.manager.feature"
+        tags:
+            - { name: twig.extension }

--- a/Tests/Fixtures/AppKernel.php
+++ b/Tests/Fixtures/AppKernel.php
@@ -25,7 +25,10 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(function ($container) {
+            $container->register('logger', \Psr\Log\NullLogger::class);
+
             $container->loadFromExtension('framework', [
+                'assets'     => [],
                 'router'     => ['resource' => '%kernel.root_dir%/config/routing.yml'],
                 'secret'     => '$ecret',
                 'test'       => true,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/symfony": "~2.3|~3.0",
+        "symfony/symfony": "~2.3|~3.0|~4.0",
         "twig/twig": "^1.12|^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": ">=5.6",
         "doctrine/annotations": "^1.3",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0",
-        "twig/twig": "^1.12|^2.0"
+        "symfony/yaml": "~2.7|~3.0|~4.0"
     },
     "require-dev": {
         "atoum/atoum": "^2.8|^3.0",
@@ -25,7 +24,11 @@
         "symfony/browser-kit": "~2.7|~3.0|~4.0",
         "symfony/css-selector": "~2.7|~3.0|~4.0",
         "symfony/templating": "~2.7|~3.0|~4.0",
-        "symfony/twig-bundle": "~2.7|~3.0|~4.0"
+        "symfony/twig-bundle": "~2.7|~3.0|~4.0",
+        "twig/twig": "^1.12|^2.0"
+    },
+    "suggest": {
+        "twig/twig": "To check feature in your Twig templates"
     },
     "autoload": {
         "psr-4": {"Novaway\\Bundle\\FeatureFlagBundle\\": ""},

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,19 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/symfony": "~2.3|~3.0|~4.0",
+        "doctrine/annotations": "^1.3",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+        "symfony/yaml": "~2.3|~3.0|~4.0",
         "twig/twig": "^1.12|^2.0"
     },
     "require-dev": {
         "atoum/atoum": "^2.8|^3.0",
+        "atoum/atoum-bundle": "^1.4",
         "atoum/stubs": "^2.5",
-        "atoum/atoum-bundle": "^1.4"
+        "symfony/asset": "~2.3|~3.0|~4.0",
+        "symfony/browser-kit": "~2.3|~3.0|~4.0",
+        "symfony/templating": "~2.3|~3.0|~4.0",
+        "symfony/twig-bundle": "~2.3|~3.0|~4.0"
     },
     "autoload": {
         "psr-4": {"Novaway\\Bundle\\FeatureFlagBundle\\": ""},

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,19 @@
     "require": {
         "php": ">=5.6",
         "doctrine/annotations": "^1.3",
-        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-        "symfony/yaml": "~2.3|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0",
         "twig/twig": "^1.12|^2.0"
     },
     "require-dev": {
         "atoum/atoum": "^2.8|^3.0",
         "atoum/atoum-bundle": "^1.4",
         "atoum/stubs": "^2.5",
-        "symfony/asset": "~2.3|~3.0|~4.0",
-        "symfony/browser-kit": "~2.3|~3.0|~4.0",
-        "symfony/templating": "~2.3|~3.0|~4.0",
-        "symfony/twig-bundle": "~2.3|~3.0|~4.0"
+        "symfony/asset": "~3.0|~4.0",
+        "symfony/browser-kit": "~2.7|~3.0|~4.0",
+        "symfony/css-selector": "~2.7|~3.0|~4.0",
+        "symfony/templating": "~2.7|~3.0|~4.0",
+        "symfony/twig-bundle": "~2.7|~3.0|~4.0"
     },
     "autoload": {
         "psr-4": {"Novaway\\Bundle\\FeatureFlagBundle\\": ""},


### PR DESCRIPTION
Because Symfony >= 3.4 introduce a default logger that record logs into `stdout` and Atoum interpret it as an error, we need to define a `Nulllogger` to avoid error.