### PR TITLE
Update maintained Symfony versions in Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
           env: SYMFONY_VERSION=4.1.*
     allow_failures:
         - php: nightly
+        - env: SYMFONY_VERSION=4.2.*@dev
 
 before_install:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ matrix:
         - php: 5.6
           env: COMPOSER_FLAGS="--prefer-lowest"
         - php: 5.6
-          env: SYMFONY_VERSION=3.2.*
-        - php: 5.6
-          env: SYMFONY_VERSION=3.3.*
-        - php: 5.6
           env: SYMFONY_VERSION=3.4.*
         - php: 7.1
           env: SYMFONY_VERSION=4.0.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
           env: SYMFONY_VERSION=3.4.*
         - php: 7.1
           env: SYMFONY_VERSION=4.0.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.1.*
     allow_failures:
         - php: nightly
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ please considerer using an another solution like [Qandidate\Toggle](https://gith
 
 ## Compatibility
 
-This bundle is tested with Symfony 2.7+, but it should be compatible with
+This bundle is tested with all maintained Symfony version, but it should be compatible with
 Symfony 2.3+.
 
 ## Documentation


### PR DESCRIPTION
Symfony 4.1 just be released today.

This PR add the new version into the Travis test matrix and remove unmaintened versions.

I've update the README about the testing strategy.