### PR TITLE
Remove atoum bundle usage

### DIFF
--- a/Tests/Fixtures/AppKernel.php
+++ b/Tests/Fixtures/AppKernel.php
@@ -18,7 +18,6 @@ class AppKernel extends Kernel
             new TwigBundle(),
             new NovawayFeatureFlagBundle(),
             new TestBundle\TestBundle(),
-            new AtoumAtoumBundle(),
         ];
     }
 
@@ -52,14 +51,6 @@ class AppKernel extends Kernel
             $container->loadFromExtension('novaway_feature_flag', [
                 'features' => [
                     'override' => false,
-                ],
-            ]);
-
-            $container->loadFromExtension('atoum', [
-                'bundles' => [
-                    'TestBundle' => [
-                        'directories' => ['Tests/Functional'],
-                    ],
                 ],
             ]);
         });

--- a/Tests/Functionals/WebTestCase.php
+++ b/Tests/Functionals/WebTestCase.php
@@ -2,17 +2,40 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Functionals;
 
-use atoum\AtoumBundle\Test\Units\WebTestCase as BaseWebTestCase;
 use mageekguy\atoum;
 use Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\AppKernel;
 
-abstract class WebTestCase extends BaseWebTestCase
+abstract class WebTestCase extends atoum\test
 {
+    private $kernel;
+
     public function __construct(atoum\adapter $adapter = null, atoum\annotations\extractor $annotationExtractor = null, atoum\asserter\generator $asserterGenerator = null, atoum\test\assertion\manager $assertionManager = null, \closure $reflectionClassFactory = null)
     {
         parent::__construct($adapter, $annotationExtractor, $asserterGenerator, $assertionManager, $reflectionClassFactory);
 
         $this->setTestNamespace('Functionals');
+    }
+
+    public function createClient(array $options = array(), array $server = array(), array $cookies = array())
+    {
+        if (null !== $this->kernel && $this->kernelReset) {
+            $this->kernel->shutdown();
+            $this->kernel->boot();
+        }
+
+        if (null === $this->kernel) {
+            $this->kernel = $this->createKernel($options);
+            $this->kernel->boot();
+        }
+
+        $client = $this->kernel->getContainer()->get('test.client');
+        $client->setServerParameters($server);
+
+        foreach ($cookies as $cookie) {
+            $client->getCookieJar()->set($cookie);
+        }
+
+        return $client;
     }
 
     protected function createKernel(array $options = array())

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     },
     "require-dev": {
         "atoum/atoum": "^2.8|^3.0",
-        "atoum/atoum-bundle": "^1.4",
         "atoum/stubs": "^2.5",
         "symfony/asset": "~3.0|~4.0",
         "symfony/browser-kit": "~2.7|~3.0|~4.0",


### PR DESCRIPTION
According to the Github repository, `AtoumBundle` seems to be unmaintained since 2017.

IMO, it's a bad idea to keep it in the project espacially for future developments and Symfony compatibility.