### PR TITLE
Fix depreciation root TreeBuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('novaway_feature_flag');
+        $treeBuilder = new TreeBuilder('novaway_feature_flag');
+        $rootNode = $treeBuilder->getRootNode($treeBuilder, 'novaway_feature_flag');
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,14 +12,23 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    const ROOT_NODE = 'novaway_feature_flag';
+
     /**
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('novaway_feature_flag');
-        $rootNode = $treeBuilder->getRootNode($treeBuilder, 'novaway_feature_flag');
+        $treeBuilder = new TreeBuilder(static::ROOT_NODE);
 
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root(static::ROOT_NODE);
+        }
+        
         $rootNode
             ->children()
                 ->scalarNode('storage')->defaultValue('novaway_feature_flag.storage.default')->end()

--- a/Tests/Fixtures/AppKernel.php
+++ b/Tests/Fixtures/AppKernel.php
@@ -31,9 +31,6 @@ class AppKernel extends Kernel
                 'router'     => ['resource' => '%kernel.root_dir%/config/routing.yml'],
                 'secret'     => '$ecret',
                 'test'       => true,
-                'templating' => [
-                    'engines' => ['twig'],
-                ],
             ]);
 
             $container->loadFromExtension('novaway_feature_flag', [


### PR DESCRIPTION
fix 'The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "novaway_feature_flag" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.'