### PR TITLE
Add Twig 3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/css-selector": "~4.0|~5.0|~6.0",
         "symfony/templating": "~4.0|~5.0|~6.0",
         "symfony/twig-bundle": "~4.0|~5.0|~6.0",
-        "twig/twig": "^v1.42.3|^2.0",
+        "twig/twig": "^v1.42.3|^2.0|^3.0",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.7",
         "phpstan/extension-installer": "^1.1",

--- a/src/DependencyInjection/NovawayFeatureFlagExtension.php
+++ b/src/DependencyInjection/NovawayFeatureFlagExtension.php
@@ -13,6 +13,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Environment;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -37,7 +38,7 @@ class NovawayFeatureFlagExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        if (class_exists('Twig_Extension')) {
+        if (class_exists(Environment::class)) {
             $loader->load('twig.yml');
         }
 

--- a/src/Twig/Extension/FeatureFlagExtension.php
+++ b/src/Twig/Extension/FeatureFlagExtension.php
@@ -10,8 +10,10 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Twig\Extension;
 
 use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class FeatureFlagExtension extends \Twig_Extension
+class FeatureFlagExtension extends AbstractExtension
 {
     /** @var StorageInterface */
     private $storage;
@@ -30,8 +32,8 @@ class FeatureFlagExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('isFeatureEnabled', [$this->storage, 'isEnabled']),
-            new \Twig_SimpleFunction('isFeatureDisabled', [$this->storage, 'isDisabled']),
+            new TwigFunction('isFeatureEnabled', [$this->storage, 'isEnabled']),
+            new TwigFunction('isFeatureDisabled', [$this->storage, 'isDisabled']),
         ];
     }
 


### PR DESCRIPTION
No BC.

All version are backward compatible with the "new" API.