### PR TITLE
Separate feature management from storage

### DIFF
--- a/src/DataCollector/FeatureCollector.php
+++ b/src/DataCollector/FeatureCollector.php
@@ -9,6 +9,7 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\DataCollector;
 
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Novaway\Bundle\FeatureFlagBundle\Model\Feature;
 use Novaway\Bundle\FeatureFlagBundle\Model\FeatureInterface;
 use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
@@ -18,14 +19,17 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 class FeatureCollector extends DataCollector
 {
+    /** @var FeatureManager */
+    private $manager;
     /** @var StorageInterface */
     private $storage;
 
     /**
      * Constructor
      */
-    public function __construct(StorageInterface $storage)
+    public function __construct(FeatureManager $manager, StorageInterface $storage)
     {
+        $this->manager = $manager;
         $this->storage = $storage;
     }
 
@@ -58,7 +62,7 @@ class FeatureCollector extends DataCollector
             array_filter(
                 $this->data['features'],
                 function (Feature $feature) {
-                    return $feature->isEnabled();
+                    return $this->manager->isEnabled($feature->getKey());
                 }
             )
         );

--- a/src/DataCollector/FeatureCollector.php
+++ b/src/DataCollector/FeatureCollector.php
@@ -10,7 +10,6 @@
 namespace Novaway\Bundle\FeatureFlagBundle\DataCollector;
 
 use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
-use Novaway\Bundle\FeatureFlagBundle\Model\Feature;
 use Novaway\Bundle\FeatureFlagBundle\Model\FeatureInterface;
 use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,8 +37,19 @@ class FeatureCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
+        $features = $this->storage->all();
+        $activeFeatureCount = count(
+            array_filter(
+                $features,
+                function (FeatureInterface $feature): bool {
+                    return $this->manager->isEnabled($feature->getKey());
+                }
+            )
+        );
+
         $this->data = [
-            'features' => $this->storage->all(),
+            'features' => $features,
+            'activeFeaturesCount' => $activeFeatureCount,
         ];
     }
 
@@ -58,14 +68,7 @@ class FeatureCollector extends DataCollector
      */
     public function getActiveFeatureCount(): int
     {
-        return count(
-            array_filter(
-                $this->data['features'],
-                function (Feature $feature) {
-                    return $this->manager->isEnabled($feature->getKey());
-                }
-            )
-        );
+        return $this->data['activeFeaturesCount'];
     }
 
     /**

--- a/src/DependencyInjection/NovawayFeatureFlagExtension.php
+++ b/src/DependencyInjection/NovawayFeatureFlagExtension.php
@@ -31,9 +31,11 @@ class NovawayFeatureFlagExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('novaway_feature_flag.features', $config['features']);
+        $container->setAlias('novaway_feature_flag.storage', $config['storage']);
 
-        $container->setAlias('novaway_feature_flag.manager.feature', $config['storage']);
-        $container->getAlias('novaway_feature_flag.manager.feature')->setPublic(true);
+        $container
+            ->setAlias('novaway_feature_flag.manager.feature', $config['storage'])
+            ->setPublic(true); // ToDo: this service should not be public. Remove it in the next major version
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/EventListener/FeatureListener.php
+++ b/src/EventListener/FeatureListener.php
@@ -9,7 +9,7 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\EventListener;
 
-use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -17,15 +17,15 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class FeatureListener implements EventSubscriberInterface
 {
-    /** @var StorageInterface */
-    private $storage;
+    /** @var FeatureManager */
+    private $manager;
 
     /**
      * Constructor
      */
-    public function __construct(StorageInterface $storage)
+    public function __construct(FeatureManager $manager)
     {
-        $this->storage = $storage;
+        $this->manager = $manager;
     }
 
     /**
@@ -39,7 +39,7 @@ class FeatureListener implements EventSubscriberInterface
         }
 
         foreach ($features as $featureConfiguration) {
-            if ($featureConfiguration['enabled'] !== $this->storage->check($featureConfiguration['feature'])) {
+            if ($featureConfiguration['enabled'] !== $this->manager->isEnabled($featureConfiguration['feature'])) {
                 throw new NotFoundHttpException();
             }
         }

--- a/src/Manager/DefaultFeatureManager.php
+++ b/src/Manager/DefaultFeatureManager.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Manager;
+
+use Novaway\Bundle\FeatureFlagBundle\Model\FeatureInterface;
+use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+
+class DefaultFeatureManager implements FeatureManager
+{
+    /** @var StorageInterface */
+    protected $storage;
+
+    public function __construct(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * @return FeatureInterface[]
+     */
+    public function all(): array
+    {
+        return $this->storage->all();
+    }
+
+    public function isEnabled(string $feature): bool
+    {
+        return $this->storage->get($feature)->isEnabled();
+    }
+
+    public function isDisabled(string $feature): bool
+    {
+        return false === $this->isEnabled($feature);
+    }
+}

--- a/src/Manager/FeatureManager.php
+++ b/src/Manager/FeatureManager.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Manager;
+
+interface FeatureManager
+{
+    /**
+     * Check if feature is enabled
+     */
+    public function isEnabled(string $feature): bool;
+
+    /**
+     * Check if feature is disabled
+     */
+    public function isDisabled(string $feature): bool;
+}

--- a/src/Manager/LegacyFeatureManager.php
+++ b/src/Manager/LegacyFeatureManager.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Manager;
+
+use Novaway\Bundle\FeatureFlagBundle\Model\FeatureInterface;
+use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+
+/**
+ * @internal
+ */
+final class LegacyFeatureManager extends DefaultFeatureManager implements StorageInterface
+{
+    public function get(string $feature): FeatureInterface
+    {
+        return $this->storage->get($feature);
+    }
+
+    public function check(string $feature): bool
+    {
+        return $this->storage->check($feature);
+    }
+}

--- a/src/Resources/config/debug.yml
+++ b/src/Resources/config/debug.yml
@@ -3,6 +3,7 @@ services:
         class: Novaway\Bundle\FeatureFlagBundle\DataCollector\FeatureCollector
         public: false
         arguments:
-            - "@novaway_feature_flag.manager.feature"
+            - "@novaway_feature_flag.manager"
+            - "@novaway_feature_flag.storage"
         tags:
             - { name: data_collector, template: "@NovawayFeatureFlag/data_collector/template.html.twig", id: "novaway_feature_flag.feature_collector" }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,17 @@
 services:
+    Novaway\Bundle\FeatureFlagBundle\Manager\DefaultFeatureManager:
+        arguments: ['@Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage']
+    Novaway\Bundle\FeatureFlagBundle\Manager\LegacyFeatureManager:
+        arguments: ['@Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage']
+    novaway_feature_flag.manager:
+        alias: 'Novaway\Bundle\FeatureFlagBundle\Manager\LegacyFeatureManager'
+
+    Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage:
+        arguments:
+            - "%novaway_feature_flag.features%"
+    novaway_feature_flag.storage.default:
+        alias: 'Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage'
+
     novaway_feature_flag.listener.controller:
         class: Novaway\Bundle\FeatureFlagBundle\EventListener\ControllerListener
         arguments:
@@ -9,11 +22,6 @@ services:
     novaway_feature_flag.listener.feature:
         class: Novaway\Bundle\FeatureFlagBundle\EventListener\FeatureListener
         arguments:
-            - "@novaway_feature_flag.manager.feature"
+            - "@novaway_feature_flag.manager"
         tags:
             - { name: kernel.event_subscriber }
-
-    novaway_feature_flag.storage.default:
-        class: Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage
-        arguments:
-            - "%novaway_feature_flag.features%"

--- a/src/Resources/config/twig.yml
+++ b/src/Resources/config/twig.yml
@@ -3,6 +3,6 @@ services:
         class: Novaway\Bundle\FeatureFlagBundle\Twig\Extension\FeatureFlagExtension
         public: false
         arguments:
-            - "@novaway_feature_flag.manager.feature"
+            - "@novaway_feature_flag.manager"
         tags:
             - { name: twig.extension }

--- a/src/Resources/views/data_collector/template.html.twig
+++ b/src/Resources/views/data_collector/template.html.twig
@@ -13,7 +13,7 @@
         {% for feature in collector.features %}
         <div class="sf-toolbar-info-piece">
             <b>{{ feature.key }}</b>
-            <span class="sf-toolbar-status">{{ feature.enabled ? '✅' : '❌' }}</span>
+            <span class="sf-toolbar-status">{{ isFeatureEnabled(feature.key) ? '✅' : '❌' }}</span>
         </div>
         {% endfor %}
     {% endset %}
@@ -46,7 +46,7 @@
                         <span style="font-style: italic">{{ feature.description }}</span>
                     {% endif %}
                 </th>
-                <td>{{ feature.enabled ? 'On' : 'Off' }}</td>
+                <td>{{ isFeatureEnabled(feature.key) ? 'On' : 'Off' }}</td>
             </tr>
         {% else %}
             <tr>

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -9,6 +9,10 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\Storage;
 
+/**
+ * @deprecated This class is deprecated since 2.3.0 and will be removed in the next major release.
+ *             Please use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager to manage feature.
+ */
 abstract class AbstractStorage implements StorageInterface
 {
     /**
@@ -25,5 +29,17 @@ abstract class AbstractStorage implements StorageInterface
     public function isDisabled(string $feature): bool
     {
         return false === $this->check($feature);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function check(string $feature): bool
+    {
+        try {
+            return $this->get($feature)->isEnabled();
+        } catch (\RuntimeException $e) {
+            return false;
+        }
     }
 }

--- a/src/Storage/ArrayStorage.php
+++ b/src/Storage/ArrayStorage.php
@@ -41,12 +41,12 @@ class ArrayStorage extends AbstractStorage
     /**
      * {@inheritdoc}
      */
-    public function check(string $feature): bool
+    public function get(string $feature): FeatureInterface
     {
         if (!isset($this->features[$feature])) {
-            return false;
+            throw new \RuntimeException("Feature '$feature' not exists.");
         }
 
-        return $this->features[$feature]->isEnabled();
+        return $this->features[$feature];
     }
 }

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -21,17 +21,31 @@ interface StorageInterface
     public function all(): array;
 
     /**
+     * Return feature flag
+     */
+    public function get(string $feature): FeatureInterface;
+
+    /**
      * Check if feature is enabled or not
+     *
+     * @deprecated This method is deprecated since 2.3.0 and will be removed in the next major release.
+     *             Please use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager instead.
      */
     public function check(string $feature): bool;
 
     /**
      * Check if feature is enabled
+     *
+     * @deprecated This method is deprecated since 2.3.0 and will be removed in the next major release.
+     *             Please use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager instead.
      */
     public function isEnabled(string $feature): bool;
 
     /**
      * Check if feature is disabled
+     *
+     * @deprecated This method is deprecated since 2.3.0 and will be removed in the next major release.
+     *             Please use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager instead.
      */
     public function isDisabled(string $feature): bool;
 }

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -22,6 +22,8 @@ interface StorageInterface
 
     /**
      * Return feature flag
+     *
+     * @throws \RuntimeException If the feature doesn't exist
      */
     public function get(string $feature): FeatureInterface;
 

--- a/src/Twig/Extension/FeatureFlagExtension.php
+++ b/src/Twig/Extension/FeatureFlagExtension.php
@@ -9,19 +9,19 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\Twig\Extension;
 
-use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class FeatureFlagExtension extends AbstractExtension
 {
-    /** @var StorageInterface */
+    /** @var FeatureManager */
     private $storage;
 
     /**
      * Constructor
      */
-    public function __construct(StorageInterface $storage)
+    public function __construct(FeatureManager $storage)
     {
         $this->storage = $storage;
     }

--- a/tests/Unit/Twig/Extension/FeatureFlagExtensionTest.php
+++ b/tests/Unit/Twig/Extension/FeatureFlagExtensionTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Unit\Twig\Extension;
 
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
 use Novaway\Bundle\FeatureFlagBundle\Twig\Extension\FeatureFlagExtension;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,8 +58,7 @@ final class FeatureFlagExtensionTest extends TestCase
      */
     private function createStorageMock(): MockObject
     {
-        $storage = $this->createMock(StorageInterface::class);
-        $storage->method('all')->willReturn(['foo']);
+        $storage = $this->createMock(FeatureManager::class);
         $storage->method('isEnabled')->willReturnCallback(function (string $feature): bool {
             return 'foo' === $feature;
         });


### PR DESCRIPTION
Currently the storage mix two concerns:
* it stores feature flags
* it manages if flags are enabled or not

To evolve the library easier and be able to add new flags type, we should separate those two concerns.

So I've introduced the `FeatureManager` interface with a `DefaultFeatureManager` implementation and deprecate feature management from `StorageInterface`.

To keep compatibility, I've add a `LegacyFeatureManager` which implement the both interface.