### PR TITLE
Fix environment variable resolution with short fflag configuration

### DIFF
--- a/src/Annotation/Feature.php
+++ b/src/Annotation/Feature.php
@@ -14,6 +14,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ *
  * @NamedArgumentConstructor()
  */
 #[Attribute]

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,7 +35,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) { return !is_array($v); })
-                            ->then(function ($v) { return ['enabled' => (bool) $v]; })
+                            ->then(function ($v) { return ['enabled' => $v]; })
                         ->end()
                         ->children()
                             ->scalarNode('description')->end()

--- a/tests/Fixtures/App/AppKernel.php
+++ b/tests/Fixtures/App/AppKernel.php
@@ -13,6 +13,7 @@ use Novaway\Bundle\FeatureFlagBundle\NovawayFeatureFlagBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -29,8 +30,9 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(function ($container) {
+        $loader->load(function (ContainerBuilder $container) {
             $container->register('logger', \Psr\Log\NullLogger::class);
+            $container->setParameter('env(FEATURE_ENVVAR)', 'false');
 
             $container->loadFromExtension('framework', [
                 'assets' => [],
@@ -53,6 +55,7 @@ class AppKernel extends Kernel
                         'enabled' => false,
                         'description' => 'Bar feature description',
                     ],
+                    'env_var' => '%env(bool:FEATURE_ENVVAR)%',
                 ],
             ]);
 

--- a/tests/Functional/DefaultFeatureStorageTest.php
+++ b/tests/Functional/DefaultFeatureStorageTest.php
@@ -57,18 +57,15 @@ final class DefaultFeatureStorageTest extends WebTestCase
     {
         $features = $this->defaultRegisteredStorage->all();
 
-        static::assertCount(3, $features);
+        static::assertCount(4, $features);
         static::assertEquals(
-            new Feature('override', false),
-            $features['override'],
-        );
-        static::assertEquals(
-            new Feature('foo', true),
-            $features['foo'],
-        );
-        static::assertEquals(
-            new Feature('bar', false, 'Bar feature description'),
-            $features['bar'],
+            [
+                'override' => new Feature('override', false),
+                'foo' => new Feature('foo', true),
+                'bar' => new Feature('bar', false, 'Bar feature description'),
+                'env_var' => new Feature('env_var', false),
+            ],
+            $features,
         );
     }
 
@@ -78,5 +75,6 @@ final class DefaultFeatureStorageTest extends WebTestCase
         yield 'feature enabled' => ['foo', true];
         yield 'feature disabled' => ['bar', false];
         yield 'unknow feature is considered as disabled' => ['my-unknow-feature', false];
+        yield 'environment variable flag' => ['env_var', false];
     }
 }


### PR DESCRIPTION
When using the short configuration with envvar:

```yaml
novaway_feature_flag:
    features:
        debug_simulate_communication: '%env(bool:ENV_VAR)%'
```

The flag value is converted as boolean before the framework resolved its value.