### PR TITLE
[V3] Clean bundle dependency container configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,17 @@ novaway_feature_flag:
 
 #### As a service
 
-The bundle adds a `novaway_feature_flag.manager.feature` service you can use in your  PHP classes.
+The bundle adds a `Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager` service you can use in your  PHP classes.
 
 ```php
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
+// ...
+
 class MyController extends Controller
 {
     public function myAction()
     {
-        $featureManager = $this->get('novaway_feature_flag.manager.feature');
+        $featureManager = $this->get(FeatureManager::class);
 
         if ($featureManager->isEnabled('my_feature_1')) {
             // my_feature_1 is enabled

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,6 +9,7 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\DependencyInjection;
 
+use Novaway\Bundle\FeatureFlagBundle\Storage\ArrayStorage;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -29,7 +30,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('storage')->defaultValue('novaway_feature_flag.storage.default')->end()
+                ->scalarNode('storage')->defaultValue(ArrayStorage::class)->end()
                 ->arrayNode('features')
                     ->useAttributeAsKey('name')
                     ->prototype('array')

--- a/src/DependencyInjection/NovawayFeatureFlagExtension.php
+++ b/src/DependencyInjection/NovawayFeatureFlagExtension.php
@@ -9,6 +9,7 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\DependencyInjection;
 
+use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -31,8 +32,7 @@ class NovawayFeatureFlagExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('novaway_feature_flag.features', $config['features']);
-        $container->setAlias('novaway_feature_flag.storage', $config['storage']);
-        $container->setAlias('novaway_feature_flag.manager.feature', $config['storage']);
+        $container->setAlias(StorageInterface::class, $config['storage']);
 
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.php');

--- a/src/Resources/config/debug.php
+++ b/src/Resources/config/debug.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  */
 
 use Novaway\Bundle\FeatureFlagBundle\DataCollector\FeatureCollector;
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
+use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -17,9 +19,8 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set('novaway_feature_flag.collector.feature', FeatureCollector::class)
-        ->private()
-        ->args([service('novaway_feature_flag.manager'), service('novaway_feature_flag.storage')])
+    $services->set(FeatureCollector::class)
+        ->args([service(FeatureManager::class), service(StorageInterface::class)])
         ->tag('data_collector', [
             'template' => '@NovawayFeatureFlag/data_collector/template.html.twig',
             'id' => 'novaway_feature_flag.feature_collector',

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -27,22 +27,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([service(StorageInterface::class)])
         ->tag('console.command');
 
-    $services->alias(FeatureManager::class, DefaultFeatureManager::class);
-
     $services->set(DefaultFeatureManager::class)
-        ->args([service(ArrayStorage::class)]);
-
-    $services->alias('novaway_feature_flag.manager', DefaultFeatureManager::class);
+        ->args([service(StorageInterface::class)]);
+    $services->alias(FeatureManager::class, DefaultFeatureManager::class);
 
     $services->set(ArrayStorage::class)
         ->args(['%novaway_feature_flag.features%']);
 
-    $services->alias('novaway_feature_flag.storage.default', ArrayStorage::class);
-
-    $services->set('novaway_feature_flag.listener.controller', ControllerListener::class)
+    $services->set(ControllerListener::class)
         ->tag('kernel.event_subscriber');
 
-    $services->set('novaway_feature_flag.listener.feature', FeatureListener::class)
-        ->args([service('novaway_feature_flag.manager')])
+    $services->set(FeatureListener::class)
+        ->args([service(FeatureManager::class)])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Novaway\Bundle\FeatureFlagBundle\Twig\Extension\FeatureFlagExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -17,8 +18,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set('novaway_feature_flag.twig.feature_extension', FeatureFlagExtension::class)
-        ->private()
-        ->args([service('novaway_feature_flag.manager')])
+    $services->set(FeatureFlagExtension::class)
+        ->args([service(FeatureManager::class)])
         ->tag('twig.extension');
 };

--- a/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
+++ b/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
@@ -7,7 +7,5 @@ services:
         Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
             tags: ['controller.service_arguments']
 
-    Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface: '@novaway_feature_flag.manager.feature'
-
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\AttributeClassDisabledController: ~
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController: ~

--- a/tests/Functional/DefaultFeatureStorageTest.php
+++ b/tests/Functional/DefaultFeatureStorageTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Functional;
 
+use Novaway\Bundle\FeatureFlagBundle\Manager\DefaultFeatureManager;
+use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Novaway\Bundle\FeatureFlagBundle\Model\Feature;
 use Novaway\Bundle\FeatureFlagBundle\Storage\StorageInterface;
 
@@ -21,12 +23,12 @@ final class DefaultFeatureStorageTest extends WebTestCase
 
     protected function setUp(): void
     {
-        $this->defaultRegisteredStorage = static::getContainer()->get('novaway_feature_flag.manager.feature');
+        $this->defaultRegisteredStorage = static::getContainer()->get(DefaultFeatureManager::class);
     }
 
-    public function testDefaultFeatureManagerIsStorage(): void
+    public function testDefaultFeatureManagerIsFeatureManager(): void
     {
-        static::assertInstanceOf(StorageInterface::class, $this->defaultRegisteredStorage);
+        static::assertInstanceOf(FeatureManager::class, $this->defaultRegisteredStorage);
     }
 
     public function testAccessAllRegisteredFeatures(): void


### PR DESCRIPTION
Related to https://github.com/novaway/NovawayFeatureFlagBundle/issues/32

Currently the bundle configuration has been write to be compatible with the v2 to allow a smooth migration from v2 & v3 (cf https://github.com/novaway/NovawayFeatureFlagBundle/issues/38).

It's now time, to clean the configuration (use FQDN for class configuration) and remove backward compatibility.