### PR TITLE
Allow to specify the exception to be throw when using attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ my_second_route:
         _features:
             - { feature: foo } # The action is accessible if "foo" is enabled ...
             - { feature: bar, enabled: true } # ... and "bar" feature is also enabled
+            - { feature: feature-42, enabled: true, exceptionClass: Symfony\Component\HttpKernel\Exception\BadRequestHttpException } # will throw a BadRequestHttpException if "feature-42" is disabled
 ```
 
 #### As a controller attribute
@@ -190,13 +191,13 @@ You can also restrict a controller access with attributes, two attributes are av
 #[IsFeatureEnabled(name: "foo")]
 class MyController extends Controller
 {
-    #[IsFeatureEnabled(name: "foo")]
+    #[IsFeatureEnabled(name: "foo", exceptionClass: BadRequestHttpException::class)]
     public function annotationFooEnabledAction(): Response
     {
         return new Response('MyController::annotationFooEnabledAction');
     }
 
-    #[IsFeatureDisabled(name: "foo")]
+    #[IsFeatureDisabled(name: "foo", exceptionClass: NotFoundHttpException::class)]
     public function annotationFooDisabledAction(): Response
     {
         return new Response('MyController::annotationFooDisabledAction');

--- a/src/Attribute/FeatureAttribute.php
+++ b/src/Attribute/FeatureAttribute.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Attribute;
+
+abstract class FeatureAttribute
+{
+    /**
+     * @param class-string<\Throwable>|null $exceptionClass
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $exceptionClass = null,
+    ) {
+        if ($this->exceptionClass) {
+            if (!class_exists($this->exceptionClass)) {
+                throw new \InvalidArgumentException("Class '{$this->exceptionClass}' does not exist.");
+            }
+
+            if (!is_a($this->exceptionClass, \Throwable::class, true)) {
+                throw new \InvalidArgumentException("Class '{$this->exceptionClass}' is not a valid exception class.");
+            }
+        }
+    }
+
+    /**
+     * @return array{feature: string, enabled: bool, exceptionClass: class-string<\Throwable>|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'feature' => $this->name,
+            'enabled' => $this->shouldBeEnabled(),
+            'exceptionClass' => $this->exceptionClass,
+        ];
+    }
+
+    abstract protected function shouldBeEnabled(): bool;
+}

--- a/src/Attribute/IsFeatureDisabled.php
+++ b/src/Attribute/IsFeatureDisabled.php
@@ -12,21 +12,10 @@ namespace Novaway\Bundle\FeatureFlagBundle\Attribute;
 use Attribute;
 
 #[Attribute]
-final class IsFeatureDisabled
+final class IsFeatureDisabled extends FeatureAttribute
 {
-    public function __construct(
-        public readonly string $name,
-    ) {
-    }
-
-    /**
-     * @return array{feature: string, enabled: bool}
-     */
-    public function toArray(): array
+    protected function shouldBeEnabled(): bool
     {
-        return [
-            'feature' => $this->name,
-            'enabled' => false,
-        ];
+        return false;
     }
 }

--- a/src/Attribute/IsFeatureEnabled.php
+++ b/src/Attribute/IsFeatureEnabled.php
@@ -12,21 +12,10 @@ namespace Novaway\Bundle\FeatureFlagBundle\Attribute;
 use Attribute;
 
 #[Attribute]
-final class IsFeatureEnabled
+final class IsFeatureEnabled extends FeatureAttribute
 {
-    public function __construct(
-        public readonly string $name,
-    ) {
-    }
-
-    /**
-     * @return array{feature: string, enabled: bool}
-     */
-    public function toArray(): array
+    protected function shouldBeEnabled(): bool
     {
-        return [
-            'feature' => $this->name,
-            'enabled' => true,
-        ];
+        return true;
     }
 }

--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -61,7 +61,7 @@ class ControllerListener implements EventSubscriberInterface
     }
 
     /**
-     * @return array<string, array{feature: string, enabled: bool}>
+     * @return array<string, array{feature: string, enabled: bool, exceptionClass: class-string<\Throwable>|null}>
      */
     private function resolveFeatures(\ReflectionClass $class, \ReflectionMethod $method): iterable
     {

--- a/src/EventListener/FeatureListener.php
+++ b/src/EventListener/FeatureListener.php
@@ -34,7 +34,7 @@ class FeatureListener implements EventSubscriberInterface
 
         foreach ($features as $featureConfiguration) {
             if ($featureConfiguration['enabled'] !== $this->manager->isEnabled($featureConfiguration['feature'])) {
-                throw new NotFoundHttpException();
+                throw $this->createFeatureException($featureConfiguration);
             }
         }
     }
@@ -44,5 +44,17 @@ class FeatureListener implements EventSubscriberInterface
         return [
             KernelEvents::CONTROLLER => 'onKernelController',
         ];
+    }
+
+    /**
+     * @param array{feature: string, enabled: bool, exceptionClass: class-string<\Throwable>|null} $featureConfiguration
+     */
+    public function createFeatureException(array $featureConfiguration): \Throwable
+    {
+        if (($featureConfiguration['exceptionClass'] ?? null) !== null) {
+            return new $featureConfiguration['exceptionClass']();
+        }
+
+        return new NotFoundHttpException();
     }
 }

--- a/tests/Fixtures/App/TestBundle/Controller/CustomExceptionController.php
+++ b/tests/Fixtures/App/TestBundle/Controller/CustomExceptionController.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller;
+
+use Novaway\Bundle\FeatureFlagBundle\Attribute\IsFeatureDisabled;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+class CustomExceptionController extends AbstractController
+{
+    public function routeWithExceptionInConfiguration(): Response
+    {
+        return new Response('OK');
+    }
+
+    #[IsFeatureDisabled('foo', exceptionClass: BadRequestHttpException::class)]
+    public function disableWithCustomException(): Response
+    {
+        return new Response('OK');
+    }
+
+    #[IsFeatureDisabled('foo', exceptionClass: ConflictHttpException::class)]
+    public function enableWithCustomException(): Response
+    {
+        return new Response('OK');
+    }
+}

--- a/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
+++ b/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
@@ -8,4 +8,5 @@ services:
             tags: ['controller.service_arguments']
 
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\AttributeClassDisabledController: ~
+    Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController: ~
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController: ~

--- a/tests/Fixtures/App/config/routing.yml
+++ b/tests/Fixtures/App/config/routing.yml
@@ -31,3 +31,20 @@ attribute_configuration_enabled:
 attribute_configuration_disabled:
     path: /attribute/disabled
     defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::attributeRouteIsAccessibleIfFeatureIsDisabled }
+
+route_custom_exception:
+    path: /configuration/custom_exception/disabled
+    defaults:
+        _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::routeWithExceptionInConfiguration
+        _features:
+            - feature: foo
+              enabled: false
+              exceptionClass: Symfony\Component\HttpKernel\Exception\GoneHttpException
+
+attribute_custom_exception_isdisabled:
+    path: /attribute/custom_exception/disabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::disableWithCustomException }
+
+attribute_custom_exception_isenabled:
+    path: /attribute/custom_exception/enabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::enableWithCustomException }

--- a/tests/Functional/Controller/CustomExceptionControllerTest.php
+++ b/tests/Functional/Controller/CustomExceptionControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Tests\Functional\Controller;
+
+use Novaway\Bundle\FeatureFlagBundle\Tests\Functional\WebTestCase;
+
+final class CustomExceptionControllerTest extends WebTestCase
+{
+    public function testFoo(): void
+    {
+        static::$client->request('GET', '/configuration/custom_exception/disabled');
+
+        static::assertSame(410, static::$client->getResponse()->getStatusCode());
+    }
+
+    public function testIsFeatureDisableAttributeWithCustomException(): void
+    {
+        static::$client->request('GET', '/attribute/custom_exception/disabled');
+
+        static::assertSame(400, static::$client->getResponse()->getStatusCode());
+    }
+
+    public function testIsFeatureEnableAttributeWithCustomException(): void
+    {
+        static::$client->request('GET', '/attribute/custom_exception/enabled');
+
+        static::assertSame(409, static::$client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Unit/Attribute/FeatureAttributeTestCase.php
+++ b/tests/Unit/Attribute/FeatureAttributeTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Tests\Unit\Attribute;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class FeatureAttributeTestCase extends TestCase
+{
+    public function testAnExceptionThrowsIfGivenExceptionClassNotExists(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createAttribute('foo', NotExistException::class);
+    }
+
+    public function testAnExceptionThrowsIfGivenExceptionClassIsNotAThrowableInstance(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createAttribute('foo', \stdClass::class);
+    }
+
+    abstract protected function createAttribute(string $name, string $exceptionClass = null);
+}

--- a/tests/Unit/Attribute/IsFeatureDisabledTest.php
+++ b/tests/Unit/Attribute/IsFeatureDisabledTest.php
@@ -12,17 +12,22 @@ declare(strict_types=1);
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Unit\Attribute;
 
 use Novaway\Bundle\FeatureFlagBundle\Attribute\IsFeatureDisabled;
-use PHPUnit\Framework\TestCase;
 
-final class IsFeatureDisabledTest extends TestCase
+final class IsFeatureDisabledTest extends FeatureAttributeTestCase
 {
     public function testIsFeatureDisabledToArrayTransformation()
     {
-        $feature = new IsFeatureDisabled('bar');
+        $feature = $this->createAttribute('bar');
 
         static::assertSame([
             'feature' => 'bar',
             'enabled' => false,
+            'exceptionClass' => null,
         ], $feature->toArray());
+    }
+
+    protected function createAttribute(string $name, string $exceptionClass = null)
+    {
+        return new IsFeatureDisabled($name, $exceptionClass);
     }
 }

--- a/tests/Unit/Attribute/IsFeatureEnabledTest.php
+++ b/tests/Unit/Attribute/IsFeatureEnabledTest.php
@@ -12,17 +12,22 @@ declare(strict_types=1);
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Unit\Attribute;
 
 use Novaway\Bundle\FeatureFlagBundle\Attribute\IsFeatureEnabled;
-use PHPUnit\Framework\TestCase;
 
-final class IsFeatureEnabledTest extends TestCase
+final class IsFeatureEnabledTest extends FeatureAttributeTestCase
 {
     public function testIsFeatureEnabledToArrayTransformation()
     {
-        $feature = new IsFeatureEnabled('bar');
+        $feature = $this->createAttribute('bar');
 
         static::assertSame([
             'feature' => 'bar',
             'enabled' => true,
+            'exceptionClass' => null,
         ], $feature->toArray());
+    }
+
+    protected function createAttribute(string $name, string $exceptionClass = null)
+    {
+        return new IsFeatureEnabled($name, $exceptionClass);
     }
 }


### PR DESCRIPTION
Closes https://github.com/novaway/NovawayFeatureFlagBundle/issues/56

Example:

```php
class CustomExceptionController extends AbstractController
{
    #[IsFeatureDisabled('foo', exceptionClass: BadRequestHttpException::class)]
    public function disableWithCustomException(): Response
    {
        return new Response('OK');
    }
}
```