### PR TITLE
Allow to specify an exception factory to use if feature constraint is not validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ my_second_route:
             - { feature: foo } # The action is accessible if "foo" is enabled ...
             - { feature: bar, enabled: true } # ... and "bar" feature is also enabled
             - { feature: feature-42, enabled: true, exceptionClass: Symfony\Component\HttpKernel\Exception\BadRequestHttpException } # will throw a BadRequestHttpException if "feature-42" is disabled
+            - { feature: feature-44, enabled: true, exceptionFactory: Symfony\Component\HttpKernel\Exception\BadRequestHttpExceptionFactory } # will use the BadRequestHttpExceptionFactory registered factory class to create the exception to be thrown
 ```
 
 #### As a controller attribute
@@ -197,7 +198,7 @@ class MyController extends Controller
         return new Response('MyController::annotationFooEnabledAction');
     }
 
-    #[IsFeatureDisabled(name: "foo", exceptionClass: NotFoundHttpException::class)]
+    #[IsFeatureDisabled(name: "foo", exceptionFactory: MyExceptionFactory::class)]
     public function annotationFooDisabledAction(): Response
     {
         return new Response('MyController::annotationFooDisabledAction');

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,10 @@
             "phpstan/extension-installer": true
         },
         "sort-packages": true
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<5.4",
+        "symfony/dom-crawler": "<5.4",
+        "symfony/routing": "<5.4"
     }
 }

--- a/src/Attribute/FeatureAttribute.php
+++ b/src/Attribute/FeatureAttribute.php
@@ -9,14 +9,18 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\Attribute;
 
+use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
+
 abstract class FeatureAttribute
 {
     /**
-     * @param class-string<\Throwable>|null $exceptionClass
+     * @param class-string<\Throwable>|null       $exceptionClass
+     * @param class-string<ExceptionFactory>|null $exceptionFactory
      */
     public function __construct(
         public readonly string $name,
         public readonly ?string $exceptionClass = null,
+        public readonly ?string $exceptionFactory = null,
     ) {
         if ($this->exceptionClass) {
             if (!class_exists($this->exceptionClass)) {
@@ -30,7 +34,12 @@ abstract class FeatureAttribute
     }
 
     /**
-     * @return array{feature: string, enabled: bool, exceptionClass: class-string<\Throwable>|null}
+     * @return array{
+     *     feature: string,
+     *     enabled: bool,
+     *     exceptionClass: class-string<\Throwable>|null,
+     *     exceptionFactory: class-string<ExceptionFactory>|null
+     * }
      */
     public function toArray(): array
     {
@@ -38,6 +47,7 @@ abstract class FeatureAttribute
             'feature' => $this->name,
             'enabled' => $this->shouldBeEnabled(),
             'exceptionClass' => $this->exceptionClass,
+            'exceptionFactory' => $this->exceptionFactory,
         ];
     }
 

--- a/src/EventListener/FeatureListener.php
+++ b/src/EventListener/FeatureListener.php
@@ -42,7 +42,7 @@ class FeatureListener implements EventSubscriberInterface
 
         foreach ($features as $featureConfiguration) {
             if ($featureConfiguration['enabled'] !== $this->manager->isEnabled($featureConfiguration['feature'])) {
-                throw $this->createFeatureException($featureConfiguration);
+                throw $this->createFeatureException($featureConfiguration, $event);
             }
         }
     }
@@ -62,7 +62,7 @@ class FeatureListener implements EventSubscriberInterface
      *     exceptionFactory: class-string<ExceptionFactory>|null,
      * } $featureConfiguration
      */
-    public function createFeatureException(array $featureConfiguration): \Throwable
+    public function createFeatureException(array $featureConfiguration, ControllerEvent $event): \Throwable
     {
         if (($featureConfiguration['exceptionClass'] ?? null) !== null) {
             return new $featureConfiguration['exceptionClass']();
@@ -71,7 +71,7 @@ class FeatureListener implements EventSubscriberInterface
         if (($featureConfiguration['exceptionFactory'] ?? null) !== null) {
             $factory = $this->factories->get($featureConfiguration['exceptionFactory']);
 
-            return $factory->create();
+            return $factory->create($featureConfiguration['feature'], $event);
         }
 
         return new NotFoundHttpException();

--- a/src/EventListener/FeatureListener.php
+++ b/src/EventListener/FeatureListener.php
@@ -9,7 +9,10 @@
 
 namespace Novaway\Bundle\FeatureFlagBundle\EventListener;
 
+use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
 use Novaway\Bundle\FeatureFlagBundle\Manager\ChainedFeatureManager;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -17,8 +20,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class FeatureListener implements EventSubscriberInterface
 {
+    /**
+     * @param ServiceLocator<ExceptionFactory> $factories
+     */
     public function __construct(
         private readonly ChainedFeatureManager $manager,
+        #[TaggedLocator(ExceptionFactory::class)]
+        private readonly ServiceLocator $factories,
     ) {
     }
 
@@ -47,12 +55,23 @@ class FeatureListener implements EventSubscriberInterface
     }
 
     /**
-     * @param array{feature: string, enabled: bool, exceptionClass: class-string<\Throwable>|null} $featureConfiguration
+     * @param array{
+     *     feature: string,
+     *     enabled: bool,
+     *     exceptionClass: class-string<\Throwable>|null,
+     *     exceptionFactory: class-string<ExceptionFactory>|null,
+     * } $featureConfiguration
      */
     public function createFeatureException(array $featureConfiguration): \Throwable
     {
         if (($featureConfiguration['exceptionClass'] ?? null) !== null) {
             return new $featureConfiguration['exceptionClass']();
+        }
+
+        if (($featureConfiguration['exceptionFactory'] ?? null) !== null) {
+            $factory = $this->factories->get($featureConfiguration['exceptionFactory']);
+
+            return $factory->create();
         }
 
         return new NotFoundHttpException();

--- a/src/Factory/ExceptionFactory.php
+++ b/src/Factory/ExceptionFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Factory;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag]
+interface ExceptionFactory
+{
+    public function create(): \Throwable;
+}

--- a/src/Factory/ExceptionFactory.php
+++ b/src/Factory/ExceptionFactory.php
@@ -10,9 +10,10 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Factory;
 
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 
 #[AutoconfigureTag]
 interface ExceptionFactory
 {
-    public function create(): \Throwable;
+    public function create(string $feature, ControllerEvent $event): \Throwable;
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -12,15 +12,17 @@ declare(strict_types=1);
 use Novaway\Bundle\FeatureFlagBundle\EventListener\ControllerListener;
 use Novaway\Bundle\FeatureFlagBundle\EventListener\FeatureListener;
 use Novaway\Bundle\FeatureFlagBundle\Factory\ArrayStorageFactory;
+use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
 use Novaway\Bundle\FeatureFlagBundle\Manager\ChainedFeatureManager;
 use Novaway\Bundle\FeatureFlagBundle\Manager\FeatureManager;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    $services->set(ExceptionFactory::class)->autoconfigure();
 
     $services->set('novaway_feature_flag.factory.array', ArrayStorageFactory::class);
 
@@ -35,6 +37,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('kernel.event_subscriber');
 
     $services->set(FeatureListener::class)
-        ->args([service(ChainedFeatureManager::class)])
+        ->autowire()
         ->tag('kernel.event_subscriber');
 };

--- a/tests/Fixtures/App/TestBundle/Controller/CustomExceptionController.php
+++ b/tests/Fixtures/App/TestBundle/Controller/CustomExceptionController.php
@@ -10,6 +10,8 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller;
 
 use Novaway\Bundle\FeatureFlagBundle\Attribute\IsFeatureDisabled;
+use Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception\Http411ExceptionFactory;
+use Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception\Http423ExceptionFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -30,6 +32,18 @@ class CustomExceptionController extends AbstractController
 
     #[IsFeatureDisabled('foo', exceptionClass: ConflictHttpException::class)]
     public function enableWithCustomException(): Response
+    {
+        return new Response('OK');
+    }
+
+    #[IsFeatureDisabled('foo', exceptionFactory: Http423ExceptionFactory::class)]
+    public function disableWithCustomExceptionFactory(): Response
+    {
+        return new Response('OK');
+    }
+
+    #[IsFeatureDisabled('foo', exceptionFactory: Http411ExceptionFactory::class)]
+    public function enableWithCustomExceptionFactory(): Response
     {
         return new Response('OK');
     }

--- a/tests/Fixtures/App/TestBundle/Exception/Http411ExceptionFactory.php
+++ b/tests/Fixtures/App/TestBundle/Exception/Http411ExceptionFactory.php
@@ -10,11 +10,12 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception;
 
 use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
 
 class Http411ExceptionFactory implements ExceptionFactory
 {
-    public function create(): \Throwable
+    public function create(string $feature, ControllerEvent $event): \Throwable
     {
         return new LengthRequiredHttpException();
     }

--- a/tests/Fixtures/App/TestBundle/Exception/Http411ExceptionFactory.php
+++ b/tests/Fixtures/App/TestBundle/Exception/Http411ExceptionFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception;
+
+use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
+use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
+
+class Http411ExceptionFactory implements ExceptionFactory
+{
+    public function create(): \Throwable
+    {
+        return new LengthRequiredHttpException();
+    }
+}

--- a/tests/Fixtures/App/TestBundle/Exception/Http423ExceptionFactory.php
+++ b/tests/Fixtures/App/TestBundle/Exception/Http423ExceptionFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the NovawayFeatureFlagBundle package.
+ * (c) Novaway <https://github.com/novaway/NovawayFeatureFlagBundle>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception;
+
+use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class Http423ExceptionFactory implements ExceptionFactory
+{
+    public function create(): \Throwable
+    {
+        return new HttpException(423);
+    }
+}

--- a/tests/Fixtures/App/TestBundle/Exception/Http423ExceptionFactory.php
+++ b/tests/Fixtures/App/TestBundle/Exception/Http423ExceptionFactory.php
@@ -10,11 +10,12 @@
 namespace Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception;
 
 use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class Http423ExceptionFactory implements ExceptionFactory
 {
-    public function create(): \Throwable
+    public function create(string $feature, ControllerEvent $event): \Throwable
     {
         return new HttpException(423);
     }

--- a/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
+++ b/tests/Fixtures/App/TestBundle/Resources/config/services.yaml
@@ -7,6 +7,9 @@ services:
         Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
             tags: ['controller.service_arguments']
 
+    Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception\Http411ExceptionFactory: ~
+    Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Exception\Http423ExceptionFactory: ~
+
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\AttributeClassDisabledController: ~
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController: ~
     Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController: ~

--- a/tests/Fixtures/App/config/routing.yml
+++ b/tests/Fixtures/App/config/routing.yml
@@ -48,3 +48,11 @@ attribute_custom_exception_isdisabled:
 attribute_custom_exception_isenabled:
     path: /attribute/custom_exception/enabled
     defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::enableWithCustomException }
+
+attribute_custom_exception_factory_isdisabled:
+    path: /attribute/custom_exception_factory/disabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::disableWithCustomExceptionFactory }
+
+attribute_custom_exception_factory_isenabled:
+    path: /attribute/custom_exception_factory/enabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\CustomExceptionController::enableWithCustomExceptionFactory }

--- a/tests/Functional/Controller/CustomExceptionControllerTest.php
+++ b/tests/Functional/Controller/CustomExceptionControllerTest.php
@@ -33,4 +33,18 @@ final class CustomExceptionControllerTest extends WebTestCase
 
         static::assertSame(409, static::$client->getResponse()->getStatusCode());
     }
+
+    public function testIsFeatureDisableAttributeWithCustomExceptionFactory(): void
+    {
+        static::$client->request('GET', '/attribute/custom_exception_factory/disabled');
+
+        static::assertSame(423, static::$client->getResponse()->getStatusCode());
+    }
+
+    public function testIsFeatureEnableAttributeWithCustomExceptionFactory(): void
+    {
+        static::$client->request('GET', '/attribute/custom_exception_factory/enabled');
+
+        static::assertSame(411, static::$client->getResponse()->getStatusCode());
+    }
 }

--- a/tests/Unit/Attribute/IsFeatureDisabledTest.php
+++ b/tests/Unit/Attribute/IsFeatureDisabledTest.php
@@ -23,6 +23,7 @@ final class IsFeatureDisabledTest extends FeatureAttributeTestCase
             'feature' => 'bar',
             'enabled' => false,
             'exceptionClass' => null,
+            'exceptionFactory' => null,
         ], $feature->toArray());
     }
 

--- a/tests/Unit/Attribute/IsFeatureEnabledTest.php
+++ b/tests/Unit/Attribute/IsFeatureEnabledTest.php
@@ -23,6 +23,7 @@ final class IsFeatureEnabledTest extends FeatureAttributeTestCase
             'feature' => 'bar',
             'enabled' => true,
             'exceptionClass' => null,
+            'exceptionFactory' => null,
         ], $feature->toArray());
     }
 


### PR DESCRIPTION
Related to https://github.com/novaway/NovawayFeatureFlagBundle/issues/56

Example:

```php
class Http411ExceptionFactory implements ExceptionFactory
{
    public function create(): \Throwable
    {
        return new LengthRequiredHttpException();
    }
}

class CustomExceptionController extends AbstractController
{
    #[IsFeatureDisabled('foo', exceptionFactory: Http411ExceptionFactory::class)]
    public function enableWithCustomExceptionFactory(): Response
    {
        return new Response('OK');
    }
}
```