### PR TITLE
Separate dev-tools from project dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,9 @@ jobs:
             restore-keys: ${{ runner.os }}-composer-
         - name: Install Dependencies
           run: composer install --prefer-dist --no-interaction --optimize-autoloader
+          working-directory: ./tools
         - name: Run PHP CS Fixer
-          run: vendor/bin/php-cs-fixer fix --dry-run --diff
+          run: tools/vendor/bin/php-cs-fixer fix --dry-run --diff
 
 
     phpstan:
@@ -46,10 +47,13 @@ jobs:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
                 restore-keys: ${{ runner.os }}-composer-
+            - name: Install Dev Tools
+              run: composer install --prefer-dist --no-interaction --optimize-autoloader
+              working-directory: ./tools
             - name: Install Dependencies
               run: composer install --prefer-dist --no-interaction --optimize-autoloader
             - name: Run PHPStan
-              run: vendor/bin/phpstan
+              run: tools/vendor/bin/phpstan
 
     tests:
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .phpunit.cache/
-tools/
+tools/vendor/
+tools/composer.lock
 vendor/
 .php-cs-fixer.cache
 composer.lock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+install: composer.install tools.install
+
+composer.install:
+	composer install
+
+clean:
+	rm -rf composer.lock vendor/
+	rm -rf tools/composer.lock tools/vendor/
+
+tools.install:
+	composer -d tools install
+
+cs:
+	tools/vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
+
+cs.fix:
+	tools/vendor/bin/php-cs-fixer fix --verbose --diff
+
+phpstan:
+	tools/vendor/bin/phpstan
+
+phpunit:
+	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,11 @@
     "require": {
         "php": ">= 8.1",
         "ext-json": "*",
+        "symfony/console": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/options-resolver": "^5.4|^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^10.1",
         "symfony/asset": "^5.4|^6.0",
         "symfony/browser-kit": "^5.4|^6.0",
@@ -38,24 +36,14 @@
         "twig/twig": "To check feature in your Twig templates"
     },
     "autoload": {
-        "psr-4": {"Novaway\\Bundle\\FeatureFlagBundle\\": "src/"},
-        "exclude-from-classmap": ["src/Tests/"]
+        "psr-4": {"Novaway\\Bundle\\FeatureFlagBundle\\": "src/"}
     },
     "autoload-dev": {
         "psr-4": {
-            "Novaway\\Bundle\\FeatureFlagBundle\\": "src/Tests/",
             "Novaway\\Bundle\\FeatureFlagBundle\\Tests\\": "tests/"
         }
     },
     "config": {
-        "allow-plugins": {
-            "phpstan/extension-installer": true
-        },
         "sort-packages": true
-    },
-    "conflict": {
-        "symfony/dependency-injection": "<5.4",
-        "symfony/dom-crawler": "<5.4",
-        "symfony/routing": "<5.4"
     }
 }

--- a/tools/composer.json
+++ b/tools/composer.json
@@ -1,0 +1,16 @@
+{
+    "require": {
+        "php": "^8.2"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.7"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        },
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
Because some dependencies (like PHP CS Fixer) are restricted to specific Symfony version and it blocks some involvement.