### PR TITLE
feat: allow Feature annotation to be repeatable

### DIFF
--- a/src/Annotation/Feature.php
+++ b/src/Annotation/Feature.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @Annotation
  * @NamedArgumentConstructor()
  */
-#[\Attribute]
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
 class Feature
 {
     /** @var string */

--- a/src/DataCollector/FeatureCollector.php
+++ b/src/DataCollector/FeatureCollector.php
@@ -32,7 +32,7 @@ class FeatureCollector extends DataCollector
         $this->storage = $storage;
     }
 
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $features = $this->storage->all();
         $activeFeatureCount = count(

--- a/src/Model/Feature.php
+++ b/src/Model/Feature.php
@@ -26,7 +26,7 @@ class Feature implements FeatureInterface
     /**
      * Constructor
      */
-    public function __construct(string $key, bool $enabled, string $description = null)
+    public function __construct(string $key, bool $enabled, ?string $description = null)
     {
         $this->key = $key;
         $this->enabled = $enabled;

--- a/tests/Fixtures/App/TestBundle/Controller/DefaultController.php
+++ b/tests/Fixtures/App/TestBundle/Controller/DefaultController.php
@@ -62,6 +62,24 @@ class DefaultController extends AbstractController
         return new Response('DefaultController::annotationFooDisabledAction');
     }
 
+    /**
+     * @Feature("foo", enabled=true)
+     * @Feature("bar", enabled=true)
+     */
+    public function annotationFooEnabledBarEnabled()
+    {
+        return new Response('DefaultController::annotationFooEnabledBarEnabledAction');
+    }
+
+    /**
+     * @Feature("foo", enabled=true)
+     * @Feature("bar", enabled=false)
+     */
+    public function annotationFooEnabledBarDisabled()
+    {
+        return new Response('DefaultController::annotationFooEnabledBarDisabledAction');
+    }
+
     #[Feature(name: 'foo')]
     public function attributeFooEnabled()
     {
@@ -72,5 +90,19 @@ class DefaultController extends AbstractController
     public function attributeFooDisabled()
     {
         return new Response('DefaultController::attributeFooDisabledAction');
+    }
+
+    #[Feature(name: 'foo', enabled: true)]
+    #[Feature(name: 'bar', enabled: true)]
+    public function attributeFooEnabledBarEnabled()
+    {
+        return new Response('DefaultController::attributeFooEnabledBarEnabledAction');
+    }
+
+    #[Feature(name: 'foo', enabled: true)]
+    #[Feature(name: 'bar', enabled: false)]
+    public function attributeFooEnabledBarDisabled()
+    {
+        return new Response('DefaultController::attributeFooEnabledBarDisabledAction');
     }
 }

--- a/tests/Fixtures/App/config/routing.yml
+++ b/tests/Fixtures/App/config/routing.yml
@@ -32,6 +32,15 @@ annotation_configuration_disabled:
     path:     /annotation/disabled
     defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::annotationFooDisabled }
 
+annotation_configuration_bar_enabled_foo_enabled:
+    path:     /annotation/bar/enabled/foo/enabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::annotationFooEnabledBarEnabled }
+
+annotation_configuration_bar_enabled_foo_disabled:
+    path:     /annotation/bar/enabled/foo/disabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::annotationFooEnabledBarDisabled }
+
+
 attribute_class_disabled:
     path:     /attribute/class/disabled
     defaults: { _controller:  Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\AttributeClassDisabledController }
@@ -43,3 +52,11 @@ attribute_configuration_enabled:
 attribute_configuration_disabled:
     path:     /attribute/disabled
     defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::attributeFooDisabled }
+
+attribute_configuration_bar_enabled_foo_enabled:
+    path:     /attribute/bar/enabled/foo/enabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::attributeFooEnabledBarEnabled }
+
+attribute_configuration_bar_enabled_foo_disabled:
+    path:     /attribute/bar/enabled/foo/disabled
+    defaults: { _controller: Novaway\Bundle\FeatureFlagBundle\Tests\Fixtures\App\TestBundle\Controller\DefaultController::attributeFooEnabledBarDisabled }

--- a/tests/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Functional/Controller/DefaultControllerTest.php
@@ -86,6 +86,30 @@ final class DefaultControllerTest extends WebTestCase
     /**
      * @requires PHP >= 8.0
      */
+    public function testTwoAnnotationsFooEnabledBarEnabledHasNoAccessBecauseFeatureFooIsEnabledButFeatureBarIsDisabled()
+    {
+        static::$client->request('GET', '/annotation/bar/enabled/foo/enabled');
+
+        static::assertSame(404, static::$client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testTwoAnnotationsFooEnabledBarDisabledHasAccessBecauseFeatureFooIsEnabledAndFeatureBarIsDisabled()
+    {
+        $crawler = static::$client->request('GET', '/annotation/bar/enabled/foo/disabled');
+
+        static::assertSame(200, static::$client->getResponse()->getStatusCode());
+        static::assertGreaterThan(
+            0,
+            $crawler->filter('html:contains("DefaultController::annotationFooEnabledBarDisabledAction")')->count(),
+        );
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
     public function testAttributeFooEnabledAction()
     {
         $crawler = static::$client->request('GET', '/attribute/enabled');
@@ -105,5 +129,29 @@ final class DefaultControllerTest extends WebTestCase
         static::$client->request('GET', '/attribute/disabled');
 
         static::assertSame(404, static::$client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testTwoAttributesFooEnabledBarEnabledHasNoAccessBecauseFeatureFooIsEnabledButFeatureBarIsDisabled()
+    {
+        static::$client->request('GET', '/attribute/bar/enabled/foo/enabled');
+
+        static::assertSame(404, static::$client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testTwoAttributesFooEnabledBarDisabledHasAccessBecauseFeatureFooIsEnabledAndFeatureBarIsDisabled()
+    {
+        $crawler = static::$client->request('GET', '/attribute/bar/enabled/foo/disabled');
+
+        static::assertSame(200, static::$client->getResponse()->getStatusCode());
+        static::assertGreaterThan(
+            0,
+            $crawler->filter('html:contains("DefaultController::attributeFooEnabledBarDisabledAction")')->count(),
+        );
     }
 }

--- a/tests/Unit/ExpressionLanguage/FeatureFlagExpressionLanguageProviderTest.php
+++ b/tests/Unit/ExpressionLanguage/FeatureFlagExpressionLanguageProviderTest.php
@@ -28,7 +28,7 @@ final class FeatureFlagExpressionLanguageProviderTest extends TestCase
         $this->featureManager = $this->createMock(FeatureManager::class);
 
         $this->expressionLanguage = new class($this->featureManager) extends ExpressionLanguage {
-            public function __construct($featureManager, CacheItemPoolInterface $cache = null, array $providers = [])
+            public function __construct($featureManager, ?CacheItemPoolInterface $cache = null, array $providers = [])
             {
                 array_unshift($providers, new FeatureFlagExpressionLanguageProvider($featureManager));
 


### PR DESCRIPTION
We should be able to require multiple features on the same controller : 
```
#[AsController]
#[Feature("MY_FEATURE_1")]
#[Feature("MY_FEATURE_2")]
class RecupererContactsController extends BaseController
{
```

Since Attribute by default has TARGET_ALL, i added it with IS_REPEATABLE. Annotation does not specify repeatable value (already the default behavior).

Code is already ready to support multiple feature attributes : https://github.com/novaway/NovawayFeatureFlagBundle/blob/2.x/src/EventListener/FeatureListener.php#L41