### PR TITLE
Replace TaggedLocator attribute with AutowireLocator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">= 8.1",
         "ext-json": "*",
         "symfony/console": "^5.4|^6.0|^7.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/options-resolver": "^5.4|^6.0|^7.0"
     },
     "require-dev": {

--- a/src/EventListener/FeatureListener.php
+++ b/src/EventListener/FeatureListener.php
@@ -11,7 +11,7 @@ namespace Novaway\Bundle\FeatureFlagBundle\EventListener;
 
 use Novaway\Bundle\FeatureFlagBundle\Factory\ExceptionFactory;
 use Novaway\Bundle\FeatureFlagBundle\Manager\ChainedFeatureManager;
-use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -25,7 +25,7 @@ class FeatureListener implements EventSubscriberInterface
      */
     public function __construct(
         private readonly ChainedFeatureManager $manager,
-        #[TaggedLocator(ExceptionFactory::class)]
+        #[AutowireLocator(ExceptionFactory::class)]
         private readonly ServiceLocator $factories,
     ) {
     }


### PR DESCRIPTION
The `TaggedLocator` class has been marked deprecated since Symfony 7.1. `AutowireLocator` has been [introduced in Symfony 6.4](https://symfony.com/blog/new-in-symfony-6-4-autowirelocator-and-autowireiterator-attributes) and is a drop-in replacement.